### PR TITLE
Switch to British English in UI texts

### DIFF
--- a/R/gene_network.R
+++ b/R/gene_network.R
@@ -41,14 +41,14 @@ create_network <- function(data, original, cancer_type, int_type, gene, include_
     }
     
     if (length(interactors_gene) == 0) {
-      validate(need(FALSE,paste(gene, "is not present in this dataset!\n Please check the spelling or select a different tumor/dataset type.")))
+      validate(need(FALSE,paste(gene, "is not present in this dataset!\n Please check the spelling or select a different tumour/dataset type.")))
     }
     
     # Extract interactors
     interactors <- unlist(interactors_gene)
     
     if (length(interactors) == 0) {
-      validate(need(FALSE,paste(gene, "has no interactors in this dataset.\n Please select a different tumor or dataset type.")))
+      validate(need(FALSE,paste(gene, "has no interactors in this dataset.\n Please select a different tumour or dataset type.")))
     }
   
   
@@ -111,7 +111,7 @@ create_network <- function(data, original, cancer_type, int_type, gene, include_
     }
     
     if (length(interactors_gene) == 0) {
-      validate(need(FALSE,paste(gene, "is not present in this dataset!\n Please select a different dataset or tumor.")))
+      validate(need(FALSE,paste(gene, "is not present in this dataset!\n Please select a different dataset or tumour.")))
     }
     
     # Extract interactors

--- a/R/main_panel_functions.R
+++ b/R/main_panel_functions.R
@@ -9,17 +9,17 @@ createMainPanel <- function() {
                      div(style = "font-size: 13px; text-align: justify;",
                          HTML("
              <h4>🧿️ Overview</h4>
-             <p><strong>CancerHubs Data Explorer</strong> is a shiny app which provides an interactive interface for exploring results from the <a href='https://github.com/ingmbioinfo/cancerhubs' target='_blank'>CancerHubs project</a>, now extended to include <strong>11 tumor types</strong>.</p>
+               <p><strong>CancerHubs Data Explorer</strong> is a shiny app which provides an interactive interface for exploring results from the <a href='https://github.com/ingmbioinfo/cancerhubs' target='_blank'>CancerHubs project</a>, now extended to include <strong>11 tumour types</strong>.</p>
 
              <p>The following gene subsets are available for exploration:</p>
              <ul>
-             <li><strong>All Genes</strong>: The complete list of genes selected by the CancerHubs framework, scored per tumor, regardless of mutation status or external annotation.</li>
+               <li><strong>All Genes</strong>: The complete list of genes selected by the CancerHubs framework, scored per tumour, regardless of mutation status or external annotation.</li>
              <li><strong>PRECOG</strong>: Genes annotated by the <a href='https://precog.stanford.edu/' target='_blank'>PRECOG</a> database, reflecting significant prognostic associations.</li>
-             <li><strong>Only Mutated</strong>: Genes identified as mutated in the tumor dataset, excluding those in PRECOG set.</li>
+               <li><strong>Only Mutated</strong>: Genes identified as mutated in the tumour dataset, excluding those in PRECOG set.</li>
              <li><strong>Only PRECOG</strong>: Genes which are significant for PRECOG Z-score that are not found mutated in the dataset.</li>
              </ul>
 
-             <p>All genes are ranked using a <strong>Network Score</strong>, which quantifies how many of their direct interaction partners are mutated within a given tumor type. By integrating protein–protein interaction data from <a href='https://thebiogrid.org/' target='_blank'>BioGRID</a> with tumor-specific mutation profiles, this score highlights genes that are highly connected to dysfunctional or altered pathways, pointing to their potential as central regulators or therapeutic targets in cancer biology.</p>
+               <p>All genes are ranked using a <strong>Network Score</strong>, which quantifies how many of their direct interaction partners are mutated within a given tumour type. By integrating protein–protein interaction data from <a href='https://thebiogrid.org/' target='_blank'>BioGRID</a> with tumour-specific mutation profiles, this score highlights genes that are highly connected to dysfunctional or altered pathways, pointing to their potential as central regulators or therapeutic targets in cancer biology.</p>
              "), 
                          hr(),
                          
@@ -37,7 +37,7 @@ createMainPanel <- function() {
                                       
                                       actionLink("go_df", strong("View Dataframes")), 
                                       
-                                      ": Explore pre-processed gene tables for each tumor type. Choose between ", 
+                                        ": Explore pre-processed gene tables for each tumour type. Choose between ",
                                       
                                       em("All Genes"), ", ", em("PRECOG"), ", ", em("Only Mutated"), ", and ", em("Only PRECOG"),
                                       
@@ -57,7 +57,7 @@ createMainPanel <- function() {
                                       
                                       actionLink("go_common", strong("Common Genes Explorer")), 
                                       
-                                      ": Identify genes that consistently rank in the top N positions across multiple tumors. View results in a dynamic heatmap and export them."
+                                      ": Identify genes that consistently rank in the top N positions across multiple tumours. View results in a dynamic heatmap and export them."
                                       
                                     ),
                                     
@@ -65,7 +65,7 @@ createMainPanel <- function() {
                                       
                                       actionLink("go_3d", strong("Network Plot (3D)")), 
                                       
-                                      ": Visualise a 3D network of the top-scoring genes in a tumor dataset. Interactions are mapped based on known BioGRID interactions. Node color, shape, and size encode multiple annotations."
+                                      ": Visualise a 3D network of the top-scoring genes in a tumour dataset. Interactions are mapped based on known BioGRID interactions. Node colour, shape, and size encode multiple annotations."
                                       
                                     ),
                                     

--- a/R/network_plot_functions.R
+++ b/R/network_plot_functions.R
@@ -1,12 +1,12 @@
 plot_tumor_network <- function(data, interactors, tumor, dataset_type = "All_Genes", top_n = 10, mutated_interactors = TRUE, color_by = "network_score") {
   # Check if the selected tumor exists in the data
   if (!tumor %in% names(data)) {
-    stop("Selected tumor is not available in the data")
+    stop("Selected tumour is not available in the data")
   }
   
   # Check if the selected dataset type exists in the tumor data
   if (!dataset_type %in% names(data[[tumor]])) {
-    stop("Selected dataset type is not available for the tumor")
+    stop("Selected dataset type is not available for the tumour")
   }
   
   # Extract data for the selected tumor and dataset type
@@ -51,7 +51,7 @@ plot_tumor_network <- function(data, interactors, tumor, dataset_type = "All_Gen
   
   # Create an igraph object from the nodes and edges
   if (length(edges) == 0) {
-    validate( need (FALSE, "The selected top genes for this tumor do not interact with each other.\n Please select more genes or change the dataset"))
+    validate( need (FALSE, "The selected top genes for this tumour do not interact with each other.\n Please select more genes or change the dataset"))
   }
   
   edges_matrix <- do.call(rbind, edges)

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -13,7 +13,7 @@ to_ordinal_expression_text <- function(x) {
 
 create_ranking_plot <- function(rankings, gene, dataframe_subset) {
   if (nrow(rankings) == 0) {
-    plot(1, type = "n", xlab = "", ylab = "", main = "Gene not found in any tumor type")
+    plot(1, type = "n", xlab = "", ylab = "", main = "Gene not found in any tumour type")
   } else {
     
     rankings$new_score = (1 - rankings$Rank/ rankings$Total)*100

--- a/R/sidebar_functions.R
+++ b/R/sidebar_functions.R
@@ -68,7 +68,7 @@ createSidebar <- function() {
   </div>
 "),
           br(),
-          selectInput("cancer_type_df", "Select Tumor:", choices = names(data)),
+          selectInput("cancer_type_df", "Select Tumour:", choices = names(data)),
           selectInput("dataframe", "Select Dataset Type:",
                       choices = c("All Genes" = "All_Genes", 
                                   "PRECOG (Mutated or Not)" = "PRECOG", 
@@ -120,7 +120,7 @@ createSidebar <- function() {
     <p>By adjusting the parameters, you can:</p>
     <ul>
       <li>Select how many <strong>top-ranking</strong> genes to consider from each tumour type</li>
-      <li>Set a threshold for how many <strong>tumors</strong> a gene must appear in to be included</li>
+      <li>Set a threshold for how many <strong>tumours</strong> a gene must appear in to be included</li>
     </ul>
 
     <p>The output includes:</p>
@@ -140,7 +140,7 @@ createSidebar <- function() {
                                   "Only MUTATED (Not Precog)" = "Non_PRECOG",
                                   "Only PRECOG (Not Mutated)" = "Only_PRECOG"), 
                       selected = "All_Genes"),
-          numericInput("num_cancers", "Min. Presence in Tumors:", value = 2),
+          numericInput("num_cancers", "Min. Presence in Tumours:", value = 2),
           br(),
           actionButton("downloadCmG", "Download Common Genes Data") 
         ),
@@ -156,16 +156,16 @@ createSidebar <- function() {
     <ul>
       <li>Choose the number of <strong>top genes</strong> to visualise</li>
       <li>Restrict nodes to <strong>mutated interactors</strong> only</li>
-      <li>Switch the coloring of nodes to show their Network Score or their <strong>PRECOG metaZ</strong></li>
+      <li>Switch the colouring of nodes to show their Network Score or their <strong>PRECOG metaZ</strong></li>
     </ul>
 
     <p>All network data, including the nodes and their connections, can be downloaded both as Excel or CSV tables. For image download, use the toolbar in the top-right corner of the network panel.</p>
   </div>
 "),
           br(),
-          selectInput("network_tumor", "Select Tumor:", choices = names(data)),
+          selectInput("network_tumor", "Select Tumour:", choices = names(data)),
           selectInput("network_dataset_type", "Select Dataset Type:",  choices = c("All Genes" = "All_Genes", "PRECOG (Mutated or Not)" = "PRECOG",  "Only MUTATED (Not Precog)" = "Non_PRECOG","Only PRECOG (not Mutated)" = "Only_PRECOG")),
-          selectInput("network_color_by", "Color by:", choices = c("network_score", "precog_metaZ")),
+          selectInput("network_color_by", "Colour by:", choices = c("network_score", "precog_metaZ")),
           numericInput("network_top_n", "Number of Top Genes:", value = 10, min = 1, max = 50),
           checkboxInput("network_mutated_interactors", "Include Only Mutated Interactors", value = TRUE),
           br(),
@@ -196,7 +196,7 @@ createSidebar <- function() {
 "),
           
           br(),
-          selectInput("g_network_tumor", "Select Tumor:", choices = names(data)),
+          selectInput("g_network_tumor", "Select Tumour:", choices = names(data)),
           selectInput("data_type_precog", "Select Dataset Type:", choices = c("All Genes", "PRECOG (Mutated or Not)","Only MUTATED (Not Precog)", "Only PRECOG (Not Mutated)")),
           textInput("gene_sel", "Enter Gene Name:", value = "TP53"),
           checkboxInput("g_network_mutated_interactors", "Include Only Mutated Interactors", value = TRUE),

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # CancerHubs Data Explorer
 
 Welcome to the **CancerHubs Data Explorer**!  
-This Shiny application provides an interactive interface for exploring results from the [CancerHubs project](https://github.com/ingmbioinfo/cancerhubs), including ranked gene data across tumor types, network visualisations, and shared hubs.
+This Shiny application provides an interactive interface for exploring results from the [CancerHubs project](https://github.com/ingmbioinfo/cancerhubs), including ranked gene data across tumour types, network visualisations, and shared hubs.
 
 🧪 **Live App**: [https://cancerhubs.app/](https://cancerhubs.app/)  
 📦 **Cancerhubs Main Repository**: [https://github.com/ingmbioinfo/cancerhubs](https://github.com/ingmbioinfo/cancerhubs)
@@ -13,16 +13,16 @@ This Shiny application provides an interactive interface for exploring results f
 ## 🔍 Features
 
 - **View Dataframes**  
-  Explore pre-processed gene tables for each tumor type. Choose between `All Genes`, `PRECOG`, `Only Mutated`, and `Only PRECOG` subsets. Download filtered data as Excel.
+  Explore pre-processed gene tables for each tumour type. Choose between `All Genes`, `PRECOG`, `Only Mutated`, and `Only PRECOG` subsets. Download filtered data as Excel.
 
 - **Gene Ranking Analysis**  
   Input a gene symbol to check its rank across cancers based on Network Score. Visualise and download the results, including a pan-cancer positioning plot.
 
 - **Common Genes Explorer**  
-  Identify genes that consistently rank in the top N positions across multiple tumors. View results in a dynamic heatmap and export them.
+  Identify genes that consistently rank in the top N positions across multiple tumours. View results in a dynamic heatmap and export them.
 
 - **Network Plot (3D)**  
-  Visualise a 3D network of the top-scoring genes in a tumor dataset. Interactions are mapped based on known BioGRID interactions. Node color, shape, and size encode multiple annotations.
+  Visualise a 3D network of the top-scoring genes in a tumour dataset. Interactions are mapped based on known BioGRID interactions. Node colour, shape, and size encode multiple annotations.
 
 - **Gene-Centric Network (2D)**  
   Explore direct interactors of any gene of interest. Visualise up to 50 interactors with igraph-style layout and download both the network image and tables.

--- a/app.R
+++ b/app.R
@@ -549,7 +549,7 @@ server <- function(input, output, session) {
                        ui = tags$div(
                          style = "font-size: 15px; padding: 15px; border-radius: 5px;",
                          tags$p(
-                           'The number of extracted lines is higher than 50, the visualization may be affected!', 
+                           'The number of extracted lines is higher than 50, the visualisation may be affected!',
                            br(),
                            'Complete data is still available for download.'
                          )
@@ -581,7 +581,7 @@ server <- function(input, output, session) {
     heatmaps <- analysis_result()
     selected <- selected_df()
     
-    if (is.null(heatmaps[[selected]]) == TRUE) {validate( need(FALSE, paste("No genes found in", selected, "with your selection! \n Please change dataset or tumor count.")))}
+    if (is.null(heatmaps[[selected]]) == TRUE) {validate( need(FALSE, paste("No genes found in", selected, "with your selection! \n Please change dataset or tumour count.")))}
     
     heatmap <- heatmaps[[selected]]
   


### PR DESCRIPTION
## Summary
- update README to use British spelling
- rewrite sidebar labels for tumour selection and colouring options
- adjust validation and notification text to match British spelling
- tweak feature descriptions in main panel

## Testing
- `Rscript -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484292b2bc8326ab88eee45f1b37ad