### PR TITLE
Ensure consistent bolding for Network Score

### DIFF
--- a/R/main_panel_functions.R
+++ b/R/main_panel_functions.R
@@ -49,7 +49,7 @@ createMainPanel <- function() {
                                       
                                       actionLink("go_rank", strong("Gene Ranking Analysis")), 
                                       
-                                      ": Input a gene symbol to check its rank across cancers based on Network Score. Visualise and download the results, including a pan-cancer positioning plot."
+                                      ": Input a gene symbol to check its rank across cancers based on <strong>Network Score</strong>. Visualise and download the results, including a pan-cancer positioning plot."
                                       
                                     ),
                                     
@@ -167,9 +167,9 @@ createMainPanel <- function() {
                      div(style = "background-color: pink; width: 20px; height: 20px; margin-right: 5px; border-radius: 50% ;"),
                      span("Input Gene"),
                      div(style = "background-color: #83C9C8; width: 20px; height: 20px; margin-left: 20px; margin-right: 5px;border-radius: 50% ;"),
-                     span("Network Score > 0"),
+                     span(tags$strong("Network Score > 0")),
                      div(style = "background-color: #C9E8E7; width: 20px; height: 20px; margin-left: 20px; margin-right: 5px;border-radius: 50%;"),
-                     span("Network Score = 0 or Not Available"),
+                     span(tags$strong("Network Score = 0 or Not Available")),
                      br(),br(),br(),br(),
                    )
                    

--- a/R/network_plot_functions.R
+++ b/R/network_plot_functions.R
@@ -139,7 +139,7 @@ plot_tumor_network <- function(data, interactors, tumor, dataset_type = "All_Gen
       cmin = if (color_by == "precog_metaZ") min(metaz_values) else min(scores),
       cmax = if (color_by == "precog_metaZ") max(metaz_values) else max(scores),
       colorbar = list(
-        title = if (color_by == "network_score") "Network Score" else "Precog MetaZ",
+        title = if (color_by == "network_score") "<b>Network Score</b>" else "Precog MetaZ",
         thickness = 10,
         len = 0.3,
         x = 1.3  # Move colorbar further to the right

--- a/R/sidebar_functions.R
+++ b/R/sidebar_functions.R
@@ -113,7 +113,7 @@ createSidebar <- function() {
           h4(tags$span(style="font-weight: bold", "Common Genes")),
           HTML("
   <div style='font-size: 13px;'>
-    <p>This panel helps identify genes that are ranked among the most relevant (Top), on the basis of their Network Score, across multiple tumour types.</p>
+    <p>This panel helps identify genes that are ranked among the most relevant (Top), on the basis of their <strong>Network Score</strong>, across multiple tumour types.</p>
 
     <p>Genes are selected based on their <strong>Network Score</strong>, which reflects their importance in tumour-specific interaction networks.</p>
 
@@ -156,7 +156,7 @@ createSidebar <- function() {
     <ul>
       <li>Choose the number of <strong>top genes</strong> to visualise</li>
       <li>Restrict nodes to <strong>mutated interactors</strong> only</li>
-      <li>Switch the colouring of nodes to show their Network Score or their <strong>PRECOG metaZ</strong></li>
+      <li>Switch the colouring of nodes to show their <strong>Network Score</strong> or their <strong>PRECOG metaZ</strong></li>
     </ul>
 
     <p>All network data, including the nodes and their connections, can be downloaded both as Excel or CSV tables. For image download, use the toolbar in the top-right corner of the network panel.</p>

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This Shiny application provides an interactive interface for exploring results f
 - **View Dataframes**  
   Explore pre-processed gene tables for each tumour type. Choose between `All Genes`, `PRECOG`, `Only Mutated`, and `Only PRECOG` subsets. Download filtered data as Excel.
 
-- **Gene Ranking Analysis**  
-  Input a gene symbol to check its rank across cancers based on Network Score. Visualise and download the results, including a pan-cancer positioning plot.
+- **Gene Ranking Analysis**
+  Input a gene symbol to check its rank across cancers based on **Network Score**. Visualise and download the results, including a pan-cancer positioning plot.
 
 - **Common Genes Explorer**  
   Identify genes that consistently rank in the top N positions across multiple tumours. View results in a dynamic heatmap and export them.

--- a/app.R
+++ b/app.R
@@ -701,7 +701,11 @@ server <- function(input, output, session) {
              main = paste("Top50 Interactors of", input$gene_sel))
         legend(
           x = 0.6, y = -1,
-          legend = c(input$gene_sel,"Network Score > 0", "Network Score = 0 or Not Available"),
+          legend = c(
+            input$gene_sel,
+            expression(bold('Network Score')~'> 0'),
+            expression(bold('Network Score')~'= 0 or Not Available')
+          ),
           col = c( "pink","#83C9C8", "#C9E8E7"),
           pch = 21,
           pt.bg = c("pink","#83C9C8", "#C9E8E7"),


### PR DESCRIPTION
## Summary
- bold Network Score in README feature description
- emphasize Network Score in sidebar and main panels
- mark Network Score in network plot colorbar and legends
- improve legend text in base R plot with expressions

## Testing
- `R -q -e "install.packages('testthat', repos='https://cloud.r-project.org')"` *(fails: package not available)*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_68484a819dfc8326bd7d9b253d1e5847