### PR TITLE
Add copy-number note for Network Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ You can use the app directly online without installation:
 
 All gene tables and interaction datasets are loaded dynamically from the original CancerHubs repository:
 
+> **Note**: The *Network Score* used to rank genes is based solely on somatic mutation data and does **not** account for copy-number variations.
+
 - [`all_results.rds`](https://github.com/ingmbioinfo/cancerhubs/blob/main/result/all_results.rds)
 - [`genes_interactors_list.rds`](https://github.com/ingmbioinfo/cancerhubs/blob/main/result/genes_interactors_list.rds)
 - [`biogrid_interactors`](https://github.com/ingmbioinfo/cancerhubs/blob/main/data/biogrid_interactors)

--- a/www/USER_MANUAL.html
+++ b/www/USER_MANUAL.html
@@ -34,6 +34,7 @@ th, td {
 <h2>1. Overview</h2>
 <p>The <strong>CancerHubs Data Explorer</strong> is an interactive web application for exploring pre-computed data from the <em>CancerHubs</em> project—a computational framework designed to predict proteins and pathways involved in cancer.</p>
 <p>By integrating <strong>mutational</strong>, <strong>interactomic</strong>, and <strong>expression–prognosis correlation</strong> data, this method ranks genes based on a <strong>Network Score</strong>, which reflects the number of direct interactors mutated in each tumour type. This scoring defines <strong>hubs of mutated proteins</strong> with potential relevance for cancer research and therapy.</p>
+<p><em>Note that the Network Score does not take copy-number variations into account.</em></p>
 <h3>Key Features:</h3>
 <ul>
 <li><strong>Ranking genes across tumour types</strong></li>


### PR DESCRIPTION
## Summary
- mention that copy-number variations are not part of the Network Score in README
- add same note in USER_MANUAL.html overview section

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd12cd3dc8326845858aeaf4e6fc5